### PR TITLE
Strip Excel trailing .0 and normalize phone/zip formatting

### DIFF
--- a/scripts/to_csv.py
+++ b/scripts/to_csv.py
@@ -34,7 +34,7 @@ def strip_trailing_zero(value):
 
 
 def fix_zip(value):
-    value = strip_trailing_zero(value)
+    value = strip_trailing_zero(value.strip("-"))
     if value.isdigit():
         if len(value) == 4:
             value = "0" + value
@@ -159,6 +159,9 @@ for filename in sys.argv[1:]:
                 row["employer_street"] += "\n" + row.pop("e-street_2")
             if "u-street_2" in row:
                 row["union_street"] += "\n" + row.pop("u-street_2")
+            for col in list(row):
+                if row[col]:
+                    row[col] = row[col].strip().strip("_")
             row["notice_date"] = fix_excel_dates(row["notice_date"])
             if "initiated_date" in row:
                 row["initiated_date"] = fix_excel_dates(row["initiated_date"])

--- a/scripts/to_csv.py
+++ b/scripts/to_csv.py
@@ -27,6 +27,41 @@ def fix_excel_dates(date_str):
     return date_str
 
 
+def strip_trailing_zero(value):
+    if value.endswith(".0"):
+        return value[:-2]
+    return value
+
+
+def fix_zip(value):
+    value = strip_trailing_zero(value)
+    if value.isdigit():
+        if len(value) == 4:
+            value = "0" + value
+        elif len(value) == 8:
+            value = "0" + value
+        if len(value) == 9:
+            return value[:5] + "-" + value[5:]
+    return value
+
+
+def fix_phone(value):
+    value = strip_trailing_zero(value)
+    if value.isdigit() and len(value) == 10:
+        return "(%s) %s-%s" % (value[:3], value[3:6], value[6:])
+    return value
+
+
+ZIP_FIELDS = (
+    "employer_zip",
+    "union_zip",
+    "affected_location_zip",
+    "location_negotiation_zip",
+)
+PHONE_FIELDS = ("employer_representative_phone", "union_representative_phone")
+INT_FIELDS = ("naics", "bargaining_unit_size", "establishment_size")
+
+
 HEADER = (
     "notice_date",
     "initiated_date",
@@ -129,5 +164,14 @@ for filename in sys.argv[1:]:
                 row["initiated_date"] = fix_excel_dates(row["initiated_date"])
             if "expiration_date" in row:
                 row["expiration_date"] = fix_excel_dates(row["expiration_date"])
+            for col in ZIP_FIELDS:
+                if col in row:
+                    row[col] = fix_zip(row[col])
+            for col in PHONE_FIELDS:
+                if col in row:
+                    row[col] = fix_phone(row[col])
+            for col in INT_FIELDS:
+                if col in row:
+                    row[col] = strip_trailing_zero(row[col])
 
             writer.writerow(row)


### PR DESCRIPTION
## Summary

Cleanups in `scripts/to_csv.py`:

- **Zip codes** (`employer_zip`, `union_zip`, `affected_location_zip`, `location_negotiation_zip`): strip trailing `.0`, pad 4- and 8-digit values (Excel-stripped leading zeros) back to 5 and 9 digits, and format 9-digit values as `#####-####`.
- **Phone numbers** (`employer_representative_phone`, `union_representative_phone`): strip trailing `.0`, format 10-digit digit-only values as `(###) ###-####`.
- **Integer-like columns** (`naics`, `bargaining_unit_size`, `establishment_size`): strip trailing `.0`.

## Before / after on a sample (FY-2008 + April-2021)

Zip code shapes:
- before: `#####`, `#####-####`, `#####.#`, `####.#`, `####`, `#########`, `#########.#`, `########.#`, ...
- after: `#####`, `#####-####` (plus a handful of irreducible anomalies)

Phone shapes:
- before: `(###) ###-####`, `##########.#`, `##########`, ...
- after: `(###) ###-####` (plus a small number of pre-existing malformed values like `( ##) ###-####`)

`naics` / `bargaining_unit_size` / `establishment_size` no longer carry trailing `.0`.

## Test plan

- [ ] Rebuild `f7.csv` and confirm no `.0` suffixes on numeric/zip/phone columns
- [ ] Confirm zips render as `#####` or `#####-####`
- [ ] Confirm phones render as `(###) ###-####`